### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/almasim.svg)](https://pypi.org/project/almasim/)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
-[![Documentation](https://github.com/MicheleDelliVeneri/ALMASim/actions/workflows/docs.yml/badge.svg)](https://michedelliveneri.github.io/ALMASim/)
+[![Documentation](https://github.com/MicheleDelliVeneri/ALMASim/actions/workflows/docs.yml/badge.svg)](https://micheledelliveneri.github.io/ALMASim/)
 [![CI](https://github.com/MicheleDelliVeneri/ALMASim/actions/workflows/lint_and_test.yml/badge.svg)](https://github.com/MicheleDelliVeneri/ALMASim/actions/workflows/lint_and_test.yml)
 [![codecov](https://codecov.io/gh/MicheleDelliVeneri/ALMASim/branch/main/graph/badge.svg)](https://codecov.io/gh/MicheleDelliVeneri/ALMASim)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -207,7 +207,7 @@ The pipeline is split into four composable stages:
 
 `estimate_simulation_footprint()` returns resolved pixel count, channel count, cell size, beam size, and raw output size in GiB — useful for pre-run capacity checks.
 
-Full reference: [Simulation docs](https://michedelliveneri.github.io/ALMASim/simulation.html)
+Full reference: [Simulation docs](https://micheledelliveneri.github.io/ALMASim/simulation.html)
 
 ---
 
@@ -233,7 +233,7 @@ All skymodels accept explicit `source_offset_x_arcsec` / `source_offset_y_arcsec
 | `dusty_diffuse` | Correlated low-spatial-frequency dusty background |
 | `combined` | Both of the above |
 
-Full reference: [Skymodels docs](https://michedelliveneri.github.io/ALMASim/skymodels.html)
+Full reference: [Skymodels docs](https://micheledelliveneri.github.io/ALMASim/skymodels.html)
 
 ---
 
@@ -249,7 +249,7 @@ Select via `SimulationParams.compute_backend`:
 | `slurm` | HPC job submission |
 | `kubernetes` | Cluster-native environments |
 
-Full reference: [Compute docs](https://michedelliveneri.github.io/ALMASim/compute.html)
+Full reference: [Compute docs](https://micheledelliveneri.github.io/ALMASim/compute.html)
 
 ---
 
@@ -284,7 +284,7 @@ products = resolve_products(df["member_ous_uid"].tolist())
 run_download_job(products, destination=Path("downloads"), extract_tar=True)
 ```
 
-Full reference: [Metadata docs](https://michedelliveneri.github.io/ALMASim/metadata.html) · [Downloads docs](https://michedelliveneri.github.io/ALMASim/downloads.html)
+Full reference: [Metadata docs](https://micheledelliveneri.github.io/ALMASim/metadata.html) · [Downloads docs](https://micheledelliveneri.github.io/ALMASim/downloads.html)
 
 ---
 
@@ -309,7 +309,7 @@ cd backend
 uv run uvicorn app.main:app --reload --port 8000
 ```
 
-Full reference: [Frontend docs](https://michedelliveneri.github.io/ALMASim/frontend.html)
+Full reference: [Frontend docs](https://micheledelliveneri.github.io/ALMASim/frontend.html)
 
 ---
 
@@ -371,21 +371,21 @@ The notebook saves query filter presets as `.query.json` files so they can be re
 
 ## Documentation
 
-Full documentation: **[michedelliveneri.github.io/ALMASim](https://michedelliveneri.github.io/ALMASim/)**
+Full documentation: **[micheledelliveneri.github.io/ALMASim](https://micheledelliveneri.github.io/ALMASim/)**
 
 | Section | Topics |
 |---|---|
-| [Quick Start](https://michedelliveneri.github.io/ALMASim/quickstart.html) | Installation, first simulation |
-| [Simulation](https://michedelliveneri.github.io/ALMASim/simulation.html) | Staged API, SimulationParams, outputs |
-| [Interferometry](https://michedelliveneri.github.io/ALMASim/interferometry.html) | UV sampling, baselines, multi-config |
-| [Noise](https://michedelliveneri.github.io/ALMASim/noise.html) | PWV-aware noise model |
-| [Background Sky](https://michedelliveneri.github.io/ALMASim/background.html) | Additive astrophysical background |
-| [Skymodels](https://michedelliveneri.github.io/ALMASim/skymodels.html) | Source models reference |
-| [Imaging](https://michedelliveneri.github.io/ALMASim/imaging.html) | Deconvolution, TP+INT combination |
-| [Metadata](https://michedelliveneri.github.io/ALMASim/metadata.html) | TAP queries, filters |
-| [Downloads](https://michedelliveneri.github.io/ALMASim/downloads.html) | Product download workflow |
-| [Compute Backends](https://michedelliveneri.github.io/ALMASim/compute.html) | Sync, Dask, Slurm, Kubernetes |
-| [Frontend](https://michedelliveneri.github.io/ALMASim/frontend.html) | Svelte UI workflows |
+| [Quick Start](https://micheledelliveneri.github.io/ALMASim/quickstart.html) | Installation, first simulation |
+| [Simulation](https://micheledelliveneri.github.io/ALMASim/simulation.html) | Staged API, SimulationParams, outputs |
+| [Interferometry](https://micheledelliveneri.github.io/ALMASim/interferometry.html) | UV sampling, baselines, multi-config |
+| [Noise](https://micheledelliveneri.github.io/ALMASim/noise.html) | PWV-aware noise model |
+| [Background Sky](https://micheledelliveneri.github.io/ALMASim/background.html) | Additive astrophysical background |
+| [Skymodels](https://micheledelliveneri.github.io/ALMASim/skymodels.html) | Source models reference |
+| [Imaging](https://micheledelliveneri.github.io/ALMASim/imaging.html) | Deconvolution, TP+INT combination |
+| [Metadata](https://micheledelliveneri.github.io/ALMASim/metadata.html) | TAP queries, filters |
+| [Downloads](https://micheledelliveneri.github.io/ALMASim/downloads.html) | Product download workflow |
+| [Compute Backends](https://micheledelliveneri.github.io/ALMASim/compute.html) | Sync, Dask, Slurm, Kubernetes |
+| [Frontend](https://micheledelliveneri.github.io/ALMASim/frontend.html) | Svelte UI workflows |
 
 Build docs locally:
 

--- a/backend/app/api/v1/routers/visualizer.py
+++ b/backend/app/api/v1/routers/visualizer.py
@@ -325,7 +325,8 @@ def _build_integrated_response(
 @router.get("/files")
 async def list_datacube_files(dir: Optional[str] = None) -> JSONResponse:
     """List supported visualizer products in the given directory."""
-    output_dir = Path(dir) if dir else Path(settings.OUTPUT_DIR)
+    base_output_dir = Path(settings.OUTPUT_DIR).resolve()
+    output_dir = _resolve_visualizer_path(dir, base_output_dir) if dir else base_output_dir
 
     if not output_dir.exists():
         return JSONResponse(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ms-casacore = ["python-casacore"]
 [project.urls]
 Repository = "https://github.com/MicheleDelliVeneri/ALMASim"
 Homepage = "https://github.com/MicheleDelliVeneri/ALMASim"
-Documentation = "https://michedelliveneri.github.io/ALMASim/"
+Documentation = "https://micheledelliveneri.github.io/ALMASim/"
 
 [dependency-groups]
 dev = [

--- a/src/almasim/services/metadata/tap/service.py
+++ b/src/almasim/services/metadata/tap/service.py
@@ -66,42 +66,41 @@ class ExclusionFilters:
     solar: bool = False  # exclude observations related to the Sun
 
 
-def get_tap_service():
-    """Establishes a connection to a TAP service for astronomical data access.
+_TAP_URLS = [
+    "https://almascience.eso.org/tap",
+    "https://almascience.nao.ac.jp/tap",
+    "https://almascience.nrao.edu/tap",
+]
 
-    This function attempts to connect to multiple TAP service endpoints until
-    a successful connection is established. It also performs a simple test query
-    to verify that the service is responding.
+_TAP_TEST_TIMEOUT = 30  # seconds for the connectivity test query
 
-    Returns:
-        pyvo.dal.TAPService: A TAP service object if a successful connection is made,
-                             otherwise None.
 
-    Notes:
-        - The function uses an infinite loop to retry connections indefinitely.
-        - It prints messages to the console indicating connection status and errors.
-        - If all URLs fail, it restarts the loop to try again from the beginning.
+def get_tap_service(max_rounds: int = 2) -> pyvo.dal.TAPService:
+    """Return a connected ALMA TAP service, trying each mirror in turn.
 
-    Dependencies:
-        - pyvo: The Python library for Virtual Observatory data access.
+    Tries each mirror URL up to *max_rounds* times total.  Raises
+    ``RuntimeError`` if every attempt fails so callers can handle the
+    failure rather than blocking forever.
     """
-    urls = [
-        "https://almascience.eso.org/tap",
-        "https://almascience.nao.ac.jp/tap",
-        "https://almascience.nrao.edu/tap",
-    ]
-    while True:  # Infinite loop to keep trying until successful
-        for url in urls:
+    errors: list[str] = []
+    for _ in range(max_rounds):
+        for url in _TAP_URLS:
             try:
                 service = pyvo.dal.TAPService(url)
-                # Test the connection with a simple query to ensure the service is working
-                service.search("SELECT TOP 1 * FROM ivoa.obscore")
+                service.search(
+                    "SELECT TOP 1 * FROM ivoa.obscore",
+                    response_timeout=_TAP_TEST_TIMEOUT,
+                )
                 print(f"Connected successfully to {url}")
                 return service
-            except Exception as e:
-                print("Failed to connect to {}: {}".format(url, e))
-                print("Retrying other servers...")
-        print("All URLs attempted and failed, retrying...")
+            except Exception as exc:
+                msg = f"{url}: {exc}"
+                errors.append(msg)
+                print(f"Failed to connect to {msg}")
+    raise RuntimeError(
+        f"All ALMA TAP mirrors unreachable after {max_rounds} rounds. Errors:\n"
+        + "\n".join(errors)
+    )
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))

--- a/src/almasim/services/metadata/tap/service.py
+++ b/src/almasim/services/metadata/tap/service.py
@@ -98,8 +98,7 @@ def get_tap_service(max_rounds: int = 2) -> pyvo.dal.TAPService:
                 errors.append(msg)
                 print(f"Failed to connect to {msg}")
     raise RuntimeError(
-        f"All ALMA TAP mirrors unreachable after {max_rounds} rounds. Errors:\n"
-        + "\n".join(errors)
+        f"All ALMA TAP mirrors unreachable after {max_rounds} rounds. Errors:\n" + "\n".join(errors)
     )
 
 

--- a/tests/unit/test_visualizer_router.py
+++ b/tests/unit/test_visualizer_router.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import json
 import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 from astropy.io import fits
 from fastapi.dependencies import utils as fastapi_dependency_utils
 
@@ -80,3 +82,84 @@ def test_complex_component_projection_uses_imaginary_part():
     cube = np.array([[[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]]], dtype=np.complex64)
     projected = visualizer._project_complex_component(cube, complex_component="imag")
     assert projected.tolist() == [[[2.0, 4.0], [6.0, 8.0]]]
+
+
+# ---------------------------------------------------------------------------
+# Tests for _resolve_visualizer_path (path-traversal guard)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_visualizer_path_valid_relative(tmp_path):
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    result = visualizer._resolve_visualizer_path("subdir", tmp_path)
+    assert result == sub.resolve()
+
+
+def test_resolve_visualizer_path_valid_absolute_inside_base(tmp_path):
+    sub = tmp_path / "inside"
+    sub.mkdir()
+    result = visualizer._resolve_visualizer_path(str(sub), tmp_path)
+    assert result == sub.resolve()
+
+
+def test_resolve_visualizer_path_rejects_traversal(tmp_path):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        visualizer._resolve_visualizer_path("../../etc/passwd", tmp_path)
+    assert exc_info.value.status_code == 400
+
+
+def test_resolve_visualizer_path_rejects_absolute_outside_base(tmp_path):
+    from fastapi import HTTPException
+
+    outside = tmp_path.parent / "outside"
+    with pytest.raises(HTTPException) as exc_info:
+        visualizer._resolve_visualizer_path(str(outside), tmp_path)
+    assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_datacube_files endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_datacube_files_no_dir_uses_output_dir(monkeypatch, tmp_path):
+    np.savez(tmp_path / "cube.npz", clean_cube=np.ones((2, 3, 4), dtype=np.float32))
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(visualizer.list_datacube_files(dir=None))
+    payload = json.loads(response.body)
+    assert payload["output_dir"] == str(tmp_path.resolve())
+    assert any(f["name"] == "cube.npz" for f in payload["files"])
+
+
+def test_list_datacube_files_with_valid_subdir(monkeypatch, tmp_path):
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    np.savez(subdir / "cube.npz", clean_cube=np.ones((2, 3, 4), dtype=np.float32))
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(visualizer.list_datacube_files(dir="sub"))
+    payload = json.loads(response.body)
+    assert any(f["name"] == "cube.npz" for f in payload["files"])
+
+
+def test_list_datacube_files_traversal_dir_rejected(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(visualizer.list_datacube_files(dir="../../etc"))
+    assert exc_info.value.status_code == 400
+
+
+def test_list_datacube_files_nonexistent_dir_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path / "nonexistent")
+
+    response = asyncio.run(visualizer.list_datacube_files(dir=None))
+    payload = json.loads(response.body)
+    assert payload["files"] == []
+    assert "does not exist" in payload["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "almasim"
-version = "2.1.10"
+version = "2.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "astromartini" },
@@ -143,13 +143,13 @@ dev = [
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "marimo", specifier = ">=0.10" },
     { name = "mypy" },
-    { name = "myst-parser", specifier = ">=3.0" },
+    { name = "myst-parser", specifier = ">=5.0.0" },
     { name = "pydantic-settings" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "sphinx", specifier = ">=7.3" },
-    { name = "sphinx-copybutton", specifier = ">=0.5" },
+    { name = "sphinx", specifier = ">=9.1.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-rtd-theme", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]


### PR DESCRIPTION
Potential fix for [https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/25](https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/25)

General fix: constrain user-supplied paths to a trusted base directory by resolving and normalizing, then enforcing containment (`resolved.relative_to(base_root)`), rejecting anything outside.

Best fix in this file: in `list_datacube_files` (around lines 326–363), stop using `Path(dir)` directly. Instead:
1. Define `base_output_dir = Path(settings.OUTPUT_DIR).resolve()`.
2. If `dir` is provided, resolve it via the existing `_resolve_visualizer_path(dir, base_output_dir)` helper (already does normalization + containment check).
3. If `dir` is not provided, use `base_output_dir`.
4. Keep existing behavior otherwise.

This preserves functionality for relative subdirectories under `OUTPUT_DIR` while blocking absolute/out-of-root paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
