### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:

--- a/backend/app/api/v1/routers/visualizer.py
+++ b/backend/app/api/v1/routers/visualizer.py
@@ -33,6 +33,23 @@ def _classify_visualizer_path(path: Path) -> str | None:
     return None
 
 
+def _resolve_visualizer_path(path: str | Path | None, base_dir: Path) -> Path:
+    base = base_dir.expanduser().resolve()
+    if not path:
+        return base
+
+    requested = Path(path).expanduser()
+    resolved = requested.resolve() if requested.is_absolute() else (base / requested).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid path",
+        ) from exc
+    return resolved
+
+
 def _iter_supported_paths(base_dir: Path) -> list[Path]:
     supported: list[Path] = []
     for pattern in ("*.npz", "*.fits", "*.fit", "*.fts"):
@@ -316,17 +333,7 @@ def _build_integrated_response(
 @router.get("/files")
 async def list_datacube_files(dir: Optional[str] = None) -> JSONResponse:
     """List supported visualizer products in the given directory."""
-    base = os.path.realpath(str(settings.OUTPUT_DIR))
-    if dir:
-        full = os.path.realpath(os.path.join(base, dir))
-        if full != base and not full.startswith(base + os.sep):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid directory",
-            )
-        output_dir = Path(full)
-    else:
-        output_dir = Path(base)
+    output_dir = _resolve_visualizer_path(dir, Path(settings.OUTPUT_DIR))
 
     if not output_dir.exists():  # lgtm[py/path-injection]
         return JSONResponse(
@@ -367,15 +374,8 @@ async def list_datacube_files(dir: Optional[str] = None) -> JSONResponse:
 @router.get("/files/{file_path:path}")
 async def get_datacube_file(file_path: str, dir: Optional[str] = None) -> FileResponse:
     """Get a visualizer file from the output directory."""
-    base = os.path.realpath(str(settings.OUTPUT_DIR))
-    sub = os.path.join(dir, file_path) if dir else file_path
-    full = os.path.realpath(os.path.join(base, sub))
-    if full != base and not full.startswith(base + os.sep):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid file path",
-        )
-    resolved = Path(full)
+    sub = Path(dir) / file_path if dir else Path(file_path)
+    resolved = _resolve_visualizer_path(sub, Path(settings.OUTPUT_DIR))
 
     if not resolved.exists() or not resolved.is_file():  # lgtm[py/path-injection]
         raise HTTPException(
@@ -428,15 +428,8 @@ async def integrate_datacube(
     tmp_path: str | None = None
     try:
         if server_path:
-            base = os.path.realpath(str(settings.OUTPUT_DIR))
-            sub = os.path.join(dir, server_path) if dir else server_path
-            full = os.path.realpath(os.path.join(base, sub))
-            if full != base and not full.startswith(base + os.sep):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid file path",
-                )
-            resolved = Path(full)
+            sub = Path(dir) / server_path if dir else Path(server_path)
+            resolved = _resolve_visualizer_path(sub, Path(settings.OUTPUT_DIR))
             if not resolved.exists():  # lgtm[py/path-injection]
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,

--- a/tests/unit/test_visualizer_router.py
+++ b/tests/unit/test_visualizer_router.py
@@ -163,3 +163,123 @@ def test_list_datacube_files_nonexistent_dir_returns_empty(monkeypatch, tmp_path
     payload = json.loads(response.body)
     assert payload["files"] == []
     assert "does not exist" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_datacube_file endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_get_datacube_file_returns_fits(monkeypatch, tmp_path):
+    cube = np.ones((2, 3, 4), dtype=np.float32)
+    fits_path = tmp_path / "cube.fits"
+    fits.PrimaryHDU(cube).writeto(fits_path)
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(visualizer.get_datacube_file("cube.fits"))
+    assert response.path == str(fits_path)
+
+
+def test_get_datacube_file_rejects_traversal(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(visualizer.get_datacube_file("../../etc/passwd"))
+    assert exc_info.value.status_code == 400
+
+
+def test_get_datacube_file_not_found(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(visualizer.get_datacube_file("nonexistent.fits"))
+    assert exc_info.value.status_code == 404
+
+
+def test_get_datacube_file_with_subdir(monkeypatch, tmp_path):
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    cube = np.ones((2, 3, 4), dtype=np.float32)
+    fits_path = subdir / "cube.fits"
+    fits.PrimaryHDU(cube).writeto(fits_path)
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(visualizer.get_datacube_file("cube.fits", dir="sub"))
+    assert response.path == str(fits_path)
+
+
+# ---------------------------------------------------------------------------
+# Tests for integrate_datacube endpoint (server_path branch)
+# ---------------------------------------------------------------------------
+
+
+def test_integrate_datacube_server_path_npz(monkeypatch, tmp_path):
+    cube = np.ones((2, 3, 4), dtype=np.float32)
+    npz_path = tmp_path / "cube.npz"
+    np.savez(npz_path, clean_cube=cube)
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(
+        visualizer.integrate_datacube(
+            method="sum",
+            integration_axis="auto",
+            complex_component="real",
+            channel_start=None,
+            channel_end=None,
+            file=None,
+            server_path="cube.npz",
+            dir=None,
+        )
+    )
+    payload = json.loads(response.body)
+    assert payload["stats"]["format"] == "npz"
+    assert payload["method"] == "sum"
+
+
+def test_integrate_datacube_server_path_traversal_rejected(monkeypatch, tmp_path):
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            visualizer.integrate_datacube(
+                method="sum",
+                integration_axis="auto",
+                complex_component="real",
+                channel_start=None,
+                channel_end=None,
+                file=None,
+                server_path="../../etc/passwd",
+                dir=None,
+            )
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_integrate_datacube_server_path_with_dir(monkeypatch, tmp_path):
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    cube = np.ones((2, 3, 4), dtype=np.float32)
+    np.savez(subdir / "cube.npz", clean_cube=cube)
+    monkeypatch.setattr(visualizer.settings, "OUTPUT_DIR", tmp_path)
+
+    response = asyncio.run(
+        visualizer.integrate_datacube(
+            method="mean",
+            integration_axis="auto",
+            complex_component="real",
+            channel_start=None,
+            channel_end=None,
+            file=None,
+            server_path="cube.npz",
+            dir="sub",
+        )
+    )
+    payload = json.loads(response.body)
+    assert payload["stats"]["format"] == "npz"
+    assert payload["method"] == "mean"


### PR DESCRIPTION
Potential fix for [https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/2](https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/2)

Add an explicit workflow-level `permissions` block with least privilege so all jobs inherit it.  
For this workflow, `contents: read` is the minimal and appropriate baseline (needed by `actions/checkout`; no write scopes are required by the shown steps).

Best single fix (no functional change):
- Edit **`.github/workflows/lint_and_test.yml`**
- Insert below the `on:` section (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
