### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/1](https://github.com/MicheleDelliVeneri/ALMASim/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/lint_and_test.yml`, directly under `on:` (or before `jobs:`), with least privilege required for these jobs. Based on the shown steps (checkout, dependency install, lint/tests), the minimal safe baseline is:

- `contents: read`

This preserves existing functionality for checkout and read-only repository access while preventing unintended write access by default. No imports, methods, or dependencies are required—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
