### PR TITLE
fix: unblock lint CI + align kaggle tests with kagglehub-first download

### DIFF
--- a/src/almasim/skymodels/datasets/galaxy_zoo.py
+++ b/src/almasim/skymodels/datasets/galaxy_zoo.py
@@ -105,9 +105,7 @@ def _download_dataset(handle: str, base_path: Path) -> None:
     try:
         import kagglehub  # modern client, supports KGAT_ bearer tokens
 
-        _run_with_c_locale(
-            lambda: kagglehub.dataset_download(handle, output_dir=str(base_path))
-        )
+        _run_with_c_locale(lambda: kagglehub.dataset_download(handle, output_dir=str(base_path)))
         return
     except ImportError:
         pass

--- a/tests/unit/test_datasets_galaxy_zoo.py
+++ b/tests/unit/test_datasets_galaxy_zoo.py
@@ -131,17 +131,20 @@ def test_load_kaggle_api_caches_result():
 # ===========================================================================
 
 
+def _patch_kagglehub(mock_download):
+    """Patch ``import kagglehub`` so the modern download path is exercised
+    without touching the network."""
+    mock_kagglehub = MagicMock()
+    mock_kagglehub.dataset_download = mock_download
+    return patch.dict(sys.modules, {"kagglehub": mock_kagglehub})
+
+
 @pytest.mark.unit
 def test_download_galaxy_zoo_creates_destination(tmp_path):
     """download_galaxy_zoo creates the destination directory."""
     dest = tmp_path / "gz"
-    mock_api = MagicMock()
 
-    _load_kaggle_api.cache_clear()
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         result = download_galaxy_zoo(dest)
 
     assert dest.is_dir()
@@ -149,32 +152,36 @@ def test_download_galaxy_zoo_creates_destination(tmp_path):
 
 
 @pytest.mark.unit
-def test_download_galaxy_zoo_calls_authenticate(tmp_path):
-    """download_galaxy_zoo calls api.authenticate()."""
+def test_download_galaxy_zoo_calls_kagglehub_download(tmp_path):
+    """download_galaxy_zoo downloads via kagglehub.dataset_download."""
     dest = tmp_path / "gz"
-    mock_api = MagicMock()
+    mock_download = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(mock_download):
         download_galaxy_zoo(dest)
 
-    mock_api.authenticate.assert_called_once()
+    mock_download.assert_called_once_with(
+        DEFAULT_GALAXY_ZOO_DATASET,
+        output_dir=str(dest),
+    )
 
 
 @pytest.mark.unit
-def test_download_galaxy_zoo_calls_dataset_download_files(tmp_path):
-    """download_galaxy_zoo calls api.dataset_download_files with correct args."""
+def test_download_galaxy_zoo_falls_back_to_legacy_kaggle(tmp_path):
+    """When kagglehub is unavailable, download_galaxy_zoo falls back to the
+    legacy kaggle client (authenticate + dataset_download_files)."""
     dest = tmp_path / "gz"
     mock_api = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
-        download_galaxy_zoo(dest)
+    _load_kaggle_api.cache_clear()
+    with patch.dict(sys.modules, {"kagglehub": None}):
+        with patch(
+            "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
+            return_value=mock_api,
+        ):
+            download_galaxy_zoo(dest)
 
+    mock_api.authenticate.assert_called_once()
     mock_api.dataset_download_files.assert_called_once_with(
         DEFAULT_GALAXY_ZOO_DATASET,
         path=str(dest),
@@ -185,12 +192,7 @@ def test_download_galaxy_zoo_calls_dataset_download_files(tmp_path):
 @pytest.mark.unit
 def test_download_galaxy_zoo_default_destination(tmp_path):
     """download_galaxy_zoo with None destination uses cwd/galaxy_zoo."""
-    mock_api = MagicMock()
-
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         with patch("pathlib.Path.cwd", return_value=tmp_path):
             result = download_galaxy_zoo(None)
 
@@ -202,12 +204,8 @@ def test_download_galaxy_zoo_default_destination(tmp_path):
 def test_download_galaxy_zoo_uses_c_locale(tmp_path):
     """download_galaxy_zoo wraps the download in C locale."""
     dest = tmp_path / "gz"
-    mock_api = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         with patch(
             "almasim.skymodels.datasets.galaxy_zoo._run_with_c_locale",
             side_effect=lambda fn: fn(),
@@ -221,12 +219,8 @@ def test_download_galaxy_zoo_uses_c_locale(tmp_path):
 def test_download_galaxy_zoo_returns_path_object(tmp_path):
     """download_galaxy_zoo returns a Path object."""
     dest = tmp_path / "gz"
-    mock_api = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.galaxy_zoo._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         result = download_galaxy_zoo(dest)
 
     assert isinstance(result, Path)

--- a/tests/unit/test_datasets_hubble.py
+++ b/tests/unit/test_datasets_hubble.py
@@ -112,20 +112,26 @@ def test_load_kaggle_api_is_cached():
 
 # ===========================================================================
 # download_hubble_top100
+#
+# The download itself is delegated to ``galaxy_zoo._download_dataset``, so the
+# kagglehub / legacy-client / C-locale seams live on the ``galaxy_zoo`` module.
 # ===========================================================================
+
+
+def _patch_kagglehub(mock_download):
+    """Patch ``import kagglehub`` so the modern download path is exercised
+    without touching the network."""
+    mock_kagglehub = MagicMock()
+    mock_kagglehub.dataset_download = mock_download
+    return patch.dict(sys.modules, {"kagglehub": mock_kagglehub})
 
 
 @pytest.mark.unit
 def test_download_hubble_top100_creates_destination(tmp_path):
     """download_hubble_top100 creates the destination directory."""
     dest = tmp_path / "hubble"
-    mock_api = MagicMock()
 
-    _load_kaggle_api.cache_clear()
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         result = download_hubble_top100(dest)
 
     assert dest.is_dir()
@@ -133,32 +139,35 @@ def test_download_hubble_top100_creates_destination(tmp_path):
 
 
 @pytest.mark.unit
-def test_download_hubble_top100_calls_authenticate(tmp_path):
-    """download_hubble_top100 calls api.authenticate()."""
+def test_download_hubble_top100_calls_kagglehub_download(tmp_path):
+    """download_hubble_top100 downloads via kagglehub.dataset_download."""
     dest = tmp_path / "hubble"
-    mock_api = MagicMock()
+    mock_download = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(mock_download):
         download_hubble_top100(dest)
 
-    mock_api.authenticate.assert_called_once()
+    mock_download.assert_called_once_with(
+        DEFAULT_HUBBLE_DATASET,
+        output_dir=str(dest),
+    )
 
 
 @pytest.mark.unit
-def test_download_hubble_top100_calls_dataset_download_files(tmp_path):
-    """download_hubble_top100 calls api.dataset_download_files correctly."""
+def test_download_hubble_top100_falls_back_to_legacy_kaggle(tmp_path):
+    """When kagglehub is unavailable, download_hubble_top100 falls back to the
+    legacy kaggle client (authenticate + dataset_download_files)."""
+    from almasim.skymodels.datasets import galaxy_zoo
+
     dest = tmp_path / "hubble"
     mock_api = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
-        download_hubble_top100(dest)
+    galaxy_zoo._load_kaggle_api.cache_clear()
+    with patch.dict(sys.modules, {"kagglehub": None}):
+        with patch.object(galaxy_zoo, "_load_kaggle_api", return_value=mock_api):
+            download_hubble_top100(dest)
 
+    mock_api.authenticate.assert_called_once()
     mock_api.dataset_download_files.assert_called_once_with(
         DEFAULT_HUBBLE_DATASET,
         path=str(dest),
@@ -169,12 +178,7 @@ def test_download_hubble_top100_calls_dataset_download_files(tmp_path):
 @pytest.mark.unit
 def test_download_hubble_top100_default_destination():
     """download_hubble_top100 with None uses cwd/hubble/top100."""
-    mock_api = MagicMock()
-
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         with patch("pathlib.Path.cwd", return_value=Path("/tmp/test_cwd")):
             result = download_hubble_top100(None)
 
@@ -185,12 +189,8 @@ def test_download_hubble_top100_default_destination():
 def test_download_hubble_top100_returns_path_object(tmp_path):
     """download_hubble_top100 returns a Path."""
     dest = tmp_path / "hubble"
-    mock_api = MagicMock()
 
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
+    with _patch_kagglehub(MagicMock()):
         result = download_hubble_top100(dest)
 
     assert isinstance(result, Path)
@@ -199,15 +199,14 @@ def test_download_hubble_top100_returns_path_object(tmp_path):
 @pytest.mark.unit
 def test_download_hubble_top100_uses_c_locale(tmp_path):
     """download_hubble_top100 wraps download in C locale."""
-    dest = tmp_path / "hubble"
-    mock_api = MagicMock()
+    from almasim.skymodels.datasets import galaxy_zoo
 
-    with patch(
-        "almasim.skymodels.datasets.hubble._load_kaggle_api",
-        return_value=mock_api,
-    ):
-        with patch(
-            "almasim.skymodels.datasets.hubble._run_with_c_locale",
+    dest = tmp_path / "hubble"
+
+    with _patch_kagglehub(MagicMock()):
+        with patch.object(
+            galaxy_zoo,
+            "_run_with_c_locale",
             side_effect=lambda fn: fn(),
         ) as mock_locale_runner:
             download_hubble_top100(dest)

--- a/tests/unit/test_metadata_tap_service.py
+++ b/tests/unit/test_metadata_tap_service.py
@@ -221,9 +221,7 @@ def test_inclusion_conditions_proposal_id_multiple():
         exclude_mosaic=False,
     )
     conds = _build_inclusion_conditions(f)
-    assert any(
-        "proposal_id IN ('2019.1.00001.S', '2022.1.00333.S')" in c for c in conds
-    )
+    assert any("proposal_id IN ('2019.1.00001.S', '2022.1.00333.S')" in c for c in conds)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What
1. **Formatting** — apply `ruff format` to `tests/unit/test_metadata_tap_service.py` and `src/almasim/skymodels/datasets/galaxy_zoo.py`, which were failing `ruff format --check` on `main` and thus failing the **lint** CI job.
2. **Kaggle tests** — once lint stopped short-circuiting the pipeline, the `tests` job ran (it had been `needs: lint` → skipped) and exposed 5 stale tests. The recent "fix kaggle" commit made `_download_dataset` prefer `kagglehub.dataset_download`, falling back to the legacy `kaggle` client only on `ImportError`; the tests still asserted the legacy path. Rewrote them to mock `kagglehub.dataset_download` (asserting the modern call) and added explicit legacy-fallback tests that force a `kagglehub` `ImportError`.

## Why
Lint had been red on `main`, which silently skipped the whole test suite on every PR. This restores a green pipeline and real test coverage of the kaggle download path.

Surfaced while reviewing/merging Dependabot PRs #181–#193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)